### PR TITLE
Use latest download artifact and be specific about the run_id

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,9 +12,10 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download PR Artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v6
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
+          run_id: ${{ github.event.workflow_run.id }}
           workflow_conclusion: success
           name: site
       - name: Store PR id as variable


### PR DESCRIPTION
Specifying just the workflow can lead to unexpected behaviour caused by trying to preview the wrong artifact.